### PR TITLE
reorder/rotate pages, change `let` to $(())

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,6 @@ For example a booklet with 8 pages:
 The printer settings would be `short-edge binding` and `2 pages per sheet` (and
 the default layout direction ` left-to-right top-to-bottom`).
 
+If your printer outputs the back-side of pages upside-down, use the
+--rotate-back-page flag, as in `bookletfromPDF.sh input.pdf --rotate-back-page`
+

--- a/bookletfromPDF.sh
+++ b/bookletfromPDF.sh
@@ -13,12 +13,18 @@ QPDF=$(which qpdf)
 OUTPUT="${1%.*}.booklet.pdf"
 
 PAGES=$("${QPDF}" --show-npages "${1}" | tr -d '\n ')
-let "m = $PAGES % 4"
+m=$(($PAGES % 4))
 [ ! "$m" -eq 0 ] && (echo "number of pages '$PAGES' has to be a multiple of 4"; exit 1)
 
-PAGEORDER=$("${PROG_DIR}/page-order.sh" "${PAGES}")
+PAGEORDER=$("${PROG_DIR}/page-order.sh" "${PAGES}" $2)
 echo "pages '$PAGES'"
-echo "$PAGEORDER"
-"${QPDF}" --empty --pages "${1}" $PAGEORDER -- "${OUTPUT}"
+
+if [ $2-- == --rotate-back-page-- ]; then
+    echo Rotating back pages...
+    ROTATE=--rotate=+180:3,4$(c=5; while [ $c -lt $PAGES ]; do echo -n ,$(($c+2)),$(($c+3)); c=$(($c+4)); done)
+else
+    ROTATE=''
+fi
+"${QPDF}" $ROTATE --empty --pages "${1}" $PAGEORDER -- "${OUTPUT}"
 echo "written to '$OUTPUT'"
 

--- a/page-order.sh
+++ b/page-order.sh
@@ -4,21 +4,24 @@
 # separated sequence of the numbers 0 to the given argument sorted in a certain
 # fashion.
 
-# check for non-empty positive input that is divisible by 4
+# check for non-empty positive input that is divisible by 4
 n="$1"
 [ -z "$n" ] && exit 1
-let "m = $n % 4"
+m=$(($n % 4))
 [ "$n" -lt 1 ] && exit 1
 [ ! "$m" -eq 0 ] && exit 1
 
 # limit for the sequence index
-let "seqlim = ($n - 4) / 2"
+seqlim=$((($n - 4) / 2))
 
 for x in $(seq 0 2 "$seqlim"); do
-  let "m1 = $n - $x"
-  let "m2 = $x + 1"
-  let "m3 = $m2 + 1" # $x + 2
-  let "m4 = $m1 - 1" # $n - $x - 1
-  echo "$m1,$m2,$m3,$m4"
+  m1=$(($n - $x))
+  m2=$(($x + 1))
+  m3=$(($m2 + 1)) # $x + 2
+  m4=$(($m1 - 1)) # $n - $x - 1
+  if [ --$2-- == --rotate-back-page-- ]; then
+    echo "$m1,$m2,$m4,$m3"
+  else
+    echo "$m1,$m2,$m3,$m4"
+  fi
 done | paste -sd "," -
-


### PR DESCRIPTION
- for when back pages are printed upside-down
- for when `let "m = 5 * 5"` gives an error in bash