### PR TITLE
fix bookletfromPDF.sh

### DIFF
--- a/bookletfromPDF.sh
+++ b/bookletfromPDF.sh
@@ -26,6 +26,6 @@ else
   ROTATE=''
 fi
 
-"${QPDF}" "$ROTATE" --empty --pages "${1}" "$PAGEORDER" -- "${OUTPUT}"
+"${QPDF}" "$ROTATE" --pages "${1}" "$PAGEORDER" -- "${OUTPUT}"
 echo "written to '$OUTPUT'"
 


### PR DESCRIPTION
fixes:

booklet-from-pdf-master ./bookletfromPDF.sh "input.pdf" /usr/local/bin/qpdf
pages '16'

qpdf: empty input can't be used since input file has already been given

For help:
  qpdf --help=usage       usage information
  qpdf --help=topic       help on a topic
  qpdf --help=--option    help on an option
  qpdf --help             general help and a topic list